### PR TITLE
This fixes BLE error - "index out of range" on non standard adv pkt

### DIFF
--- a/bluetoothlowenergy/devicejs.json
+++ b/bluetoothlowenergy/devicejs.json
@@ -20,7 +20,7 @@
         "handlebars": "4.0.5",
         "jsonminify": "^0.2.3",
         "mkdirp": "^0.5.1",
-        "noble": "^1.9.1",
+	"@abandonware/noble": "git+https://github.com/voxel-dot-at/noble.git#9f17a2e0524df8136b364e10edbac27d83081a65",
         "promise": "^7.0.4",
         "underscore": "*"
     },

--- a/bluetoothlowenergy/devicejs.json
+++ b/bluetoothlowenergy/devicejs.json
@@ -20,7 +20,7 @@
         "handlebars": "4.0.5",
         "jsonminify": "^0.2.3",
         "mkdirp": "^0.5.1",
-	"@abandonware/noble": "git+https://github.com/voxel-dot-at/noble.git#9f17a2e0524df8136b364e10edbac27d83081a65",
+        "@abandonware/noble": "git+https://github.com/voxel-dot-at/noble.git#9f17a2e0524df8136b364e10edbac27d83081a65",
         "promise": "^7.0.4",
         "underscore": "*"
     },

--- a/bluetoothlowenergy/src/init-noble.js
+++ b/bluetoothlowenergy/src/init-noble.js
@@ -23,7 +23,7 @@
 **/
 
 'use strict';
-const noble = require('noble');
+const noble = require('@abandonware/noble');
 const Logger = require('./../utils/logger');
 const helper = require('./../utils/helper').helper;
 const EventEmitter = require('events').EventEmitter;


### PR DESCRIPTION
noble library crashes on custom BLE Advertisement packet. Noble library
is not longer maintained by the author thus moving to @abondware/noble,
as its being maintained actively. This library adds try and catch in order to avoid parsing non-standard BLE advertisement packets. 