### PR TITLE
Use HTTPS for dependencies as they are less likely to be blocked by a…

### DIFF
--- a/RelayStatsSender/devicejs.json
+++ b/RelayStatsSender/devicejs.json
@@ -14,7 +14,7 @@
     "dependencies": {
       "request": "2.60.0",
       "semver": "5.3.0",
-      "devjs-configurator": "git+ssh://git@github.com:armPelionEdge/devjs-configurator.git#master"
+      "devjs-configurator": "https://github.com/armPelionEdge/devjs-configurator#master"
     },
     "devDependencies": {
     },

--- a/rsmi/devicejs.json
+++ b/rsmi/devicejs.json
@@ -19,7 +19,7 @@
         "mkdirp": "^0.5.1",
         "jsonminify" : "^0.2.3",
         "es6-promise": "^3.0.2",
-        "node-znp": "git+ssh://git@github.com:armPelionEdge/node-znp.git#master",
+        "node-znp": "https://github.com/armPelionEdge/node-znp#master",
         "commander": "2.9.0"
     },
     "devDependencies": {},

--- a/zigbeeHA/devicejs.json
+++ b/zigbeeHA/devicejs.json
@@ -13,7 +13,7 @@
     "private": true,
     "dependencies": {
         "devjs-configurator": "https://github.com/armPelionEdge/devjs-configurator#master",
-        "node-znp": "git+ssh://git@github.com:armPelionEdge/node-znp.git#master",
+        "node-znp": "https://github.com/armPelionEdge/node-znp#master",
         "jsonminify" : "^0.2.3",
         "es6-promise": "^3.0.2",
         "mkdirp": "^0.5.1",


### PR DESCRIPTION
… firewall